### PR TITLE
Fix installation on systems that don't install zsh in /bin/zsh

### DIFF
--- a/install
+++ b/install
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 target="${HOME:A}"
 source="${0:A:h}/config"


### PR DESCRIPTION
I tried installing this on a FreeBSD and it didn't work. This is because FreeBSD doesn't install zsh in /bin/zsh as default.

I have changed to `/usr/bin/env zsh` and it works a lot better. Tested on Debian 10 and FreeBSD 12