### PR TITLE
Always turn off hardstatus.

### DIFF
--- a/config/screenrc
+++ b/config/screenrc
@@ -12,8 +12,7 @@ bindkey "^[[1;5C" next  # change window with ctrl-right
 bindkey "^[[C" next  # PuTTY...
 
 termcapinfo xterm*|Eterm|mlterm "hs:ts=\E]0;:fs=\007:ds=\E]0;screen\007"
-hardstatus off
-hardstatus string "$USER@%H%?: %t%?"
+hardstatus ignore
 caption always "%{= wr}[%{k}%H%{r}]%=%{k} %?%-Lw%?%{kr}[%{w}%n*%f %t%? (%h)%?%? %{r}(%{w}%u%{r})%?%{r}]%{wk}%?%+Lw%? %=%{r}[%{k}%c%{r}]"
 
 defscrollback 2000


### PR DESCRIPTION
You might believe that "hardstatus off" does this, but it is actually
"hardstatus ignore" that is the correct command. FreeBSD installs a
default hardstatus line and it looks a bit strange with both that and a
caption.