### PR TITLE
Update git cob alias

### DIFF
--- a/config/gitconfig.dotfiles
+++ b/config/gitconfig.dotfiles
@@ -8,7 +8,7 @@
 	ci = commit
 	co = checkout
 	cof = !git fetch && git checkout
-	cob = !git fetch && git checkout -b $1 origin/master && :
+	cob = !git fetch && git checkout -b $1 --no-track $(git symbolic-ref refs/remotes/origin/HEAD) && :
 	cp = cherry-pick
 	m = !git merge --no-ff origin/$1 && :
 	sha1 = rev-parse HEAD


### PR DESCRIPTION
So, I finally managed to get the aliases setup on my Windows/Bash machine. And I noticed a problem with the "cob"/"ps" workflow. Turned out the problem was cob command.

The old command only supported master as the default branch, this one dynamically detects it.

Also it won't set the tracking branch to origin/master any longer, instead the branch will be created without any tracking information, and the tracking information will be set when a push is performed instead.